### PR TITLE
fix: create display dirs before copy

### DIFF
--- a/scripts/reTerminal.sh
+++ b/scripts/reTerminal.sh
@@ -278,9 +278,12 @@ function install {
   setup_overlay reTerminal tp_rotate=1
 
   # display
-  mkdir -p /usr/share/plymouth/themes/ \
+ if ! [[ -d "/usr/share/plymouth/themes/" && -d "/usr/share/X11/xorg.conf.d/" && -d "/etc/plymouth/" ]];
+  then
+    mkdir -p /usr/share/plymouth/themes/ \
     /usr/share/X11/xorg.conf.d/ \
-    /etc/plymouth/ || exit 1;
+    /etc/plymouth/
+  fi
   cp -rfv ${RES_PATH}/plymouth/seeed/ /usr/share/plymouth/themes/ || exit 1;
   cp -fv ${RES_PATH}/10-disp.conf /usr/share/X11/xorg.conf.d/ || exit 1;
   cp -fv ${RES_PATH}/plymouth/plymouthd.conf /etc/plymouth/ || exit 1;

--- a/scripts/reTerminal.sh
+++ b/scripts/reTerminal.sh
@@ -278,6 +278,9 @@ function install {
   setup_overlay reTerminal tp_rotate=1
 
   # display
+  mkdir -p /usr/share/plymouth/themes/ \
+    /usr/share/X11/xorg.conf.d/ \
+    /etc/plymouth/ || exit 1;
   cp -rfv ${RES_PATH}/plymouth/seeed/ /usr/share/plymouth/themes/ || exit 1;
   cp -fv ${RES_PATH}/10-disp.conf /usr/share/X11/xorg.conf.d/ || exit 1;
   cp -fv ${RES_PATH}/plymouth/plymouthd.conf /etc/plymouth/ || exit 1;


### PR DESCRIPTION
Fix for the reTerminal script, ensures the three directories referenced under `# display` are created before attempting to copy files into them.

I was following the docs here: https://wiki.seeedstudio.com/reTerminal/#flash-raspberry-pi-os-64-bit-ubuntu-os-or-other-os-to-emmc when I ran into a few issues running `reTermina.sh`

```
'overlays/rpi/reTerminal-overlay.dtbo' -> '/boot/overlays/reTerminal.dtbo'
cp: cannot create directory '/usr/share/plymouth/themes/': No such file or directory
---
'/home/pwnpi/downloads/seeed-linux-dtoverlays/extras/reTerminal/resources/10-disp.conf' -> '/usr/share/X11/xorg.conf.d/'
cp: cannot create regular file '/usr/share/X11/xorg.conf.d/': Not a directory
---
'/home/pwnpi/downloads/seeed-linux-dtoverlays/extras/reTerminal/resources/plymouth/plymouthd.conf' -> '/etc/plymouth/'
cp: cannot create regular file '/etc/plymouth/': Not a directory
```

After manually creating these directories, the install script succeeds, though as of now I am still testing if that is a viable solution, but the install script should no longer fail.