### PR TITLE
20220913 GRO-DROP-fix - master branch

### DIFF
--- a/modules/lan7800/lan78xx.c
+++ b/modules/lan7800/lan78xx.c
@@ -3508,8 +3508,6 @@ static void lan78xx_skb_return(struct lan78xx_net *dev, struct sk_buff *skb)
 
 	gro_result = napi_gro_receive(&dev->napi, skb);
 
-	if (gro_result == GRO_DROP)
-		netif_dbg(dev, rx_err, dev->net, "GRO packet dropped\n");
 }
 
 static int lan78xx_rx(struct lan78xx_net *dev, struct sk_buff *skb,


### PR DESCRIPTION
As reported in #50, trying to run `./scripts/cm4_lan7800.sh` results in a build failure because `GRO_DROP` is not declared.

Searching https://linux-commits-search.typesense.org for `GRO_DROP` reveals that it has been removed:

   https://github.com/torvalds/linux/commit/38f7b449256490c312e4e83101075201fb5f87d1

Because `GRO_DROP` can now never be returned, the "GRO packet dropped" debug message can never be produced. The simplest fix is to remove the check and implicitly ignore the content of `gro_result`.

After making that change:

```
$ sudo ./scripts/cm4_lan7800.sh
Installed: /usr/src/linux-headers-5.15.61-v8+
make: Entering directory '/usr/src/linux-headers-5.15.61-v8+'
  CC [M]  /home/pi/seeed-linux-dtoverlays/modules/lan7800/lan78xx.o
  LD [M]  /home/pi/seeed-linux-dtoverlays/modules/lan7800/lan7800.o
  MODPOST /home/pi/seeed-linux-dtoverlays/modules/lan7800/Module.symvers
  CC [M]  /home/pi/seeed-linux-dtoverlays/modules/lan7800/lan7800.mod.o
  LD [M]  /home/pi/seeed-linux-dtoverlays/modules/lan7800/lan7800.ko
make: Leaving directory '/usr/src/linux-headers-5.15.61-v8+'
'/home/pi/seeed-linux-dtoverlays/modules/lan7800/lan7800.ko' -> '/lib/modules/5.15.61-v8+/extra/seeed/lan7800.ko'
------------------------------------------------------
Please reboot your device to apply all settings
Enjoy!
------------------------------------------------------
```

Fixes #50.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>