### PR TITLE
mipi_dsi: modify printk message

### DIFF
--- a/modules/mipi_dsi/mipi_dsi.h
+++ b/modules/mipi_dsi/mipi_dsi.h
@@ -41,17 +41,16 @@
 #include <linux/input/mt.h>
 #include <linux/input/touchscreen.h>
 
+#define MIPI_DSI_DRIVER_NAME        "mipi_dsi"
 
 #define I2C_DSI_DBG
 #ifdef I2C_DSI_DBG
-#define DBG_FUNC(format, x...)		printk(KERN_INFO "[DSI]%s:" format"\n", __func__, ##x)
-#define DBG_PRINT(format, x...)		printk(KERN_INFO "[DSI]" format"\n", ##x)
+#define DBG_FUNC(format, x...)      printk(KERN_INFO MIPI_DSI_DRIVER_NAME ": (%s) " format "\n", __func__, ##x)
+#define DBG_PRINT(format, x...)     printk(KERN_INFO MIPI_DSI_DRIVER_NAME ": " format "\n", ##x)
 #else
 #define DBG_FUNC(format, x...)
 #define DBG_PRINT(format, x...)
 #endif
-
-#define DSI_DRIVER_NAME		        "i2c_mipi_dsi"
 
 /* i2c: commands */
 enum REG_ADDR {

--- a/modules/mipi_dsi/mipi_dsi_drv.c
+++ b/modules/mipi_dsi/mipi_dsi_drv.c
@@ -11,9 +11,6 @@
 #include "mipi_dsi.h"
 #include <linux/version.h>
 
-////////////////////////////////////////////////////////////////////////////////
-// I2C read/write functions
-
 /*static */int i2c_md_read(struct i2c_mipi_dsi *md, u8 reg, u8 *buf, int len)
 {
 	struct i2c_client *client = md->i2c;
@@ -78,7 +75,7 @@
 	mutex_unlock(&md->mutex);
 }
 
-////////////////////////////////////////////////////////////////////////////////
+
 // MIPI-DSI driver
 
 static int mipi_dsi_probe(struct mipi_dsi_device *dsi)
@@ -100,7 +97,7 @@ static struct mipi_dsi_driver mipi_dsi_driver = {
 	.probe = mipi_dsi_probe,
 };
 
-////////////////////////////////////////////////////////////////////////////////
+
 // MIPI-DSI device
 
 static struct mipi_dsi_device *mipi_dsi_device(struct device *dev)
@@ -156,7 +153,7 @@ error:
 	return NULL;
 }
 
-////////////////////////////////////////////////////////////////////////////////
+
 // Panel
 
 static int panel_prepare(struct drm_panel *panel)
@@ -254,8 +251,6 @@ static int panel_get_modes(struct drm_panel *panel, struct drm_connector *connec
 	struct i2c_mipi_dsi *md = panel_to_md(panel);
 	const struct drm_panel_funcs *funcs = md->panel_data->funcs;
 
-	// DBG_PRINT("Get panel mode");
-
 	if (funcs && funcs->get_modes) {
 		ret = funcs->get_modes(panel, connector);
 		if (ret < 0)
@@ -273,15 +268,13 @@ static const struct drm_panel_funcs panel_funcs = {
 	.get_modes = panel_get_modes,
 };
 
-////////////////////////////////////////////////////////////////////////////////
+
 // Backlight device
 
 static int backlight_update(struct backlight_device *bd)
 {
 	struct i2c_mipi_dsi *md = bl_get_data(bd);
 	int brightness = bd->props.brightness;
-
-	// DBG_PRINT("Update backlight status");
 
 	if (bd->props.power != FB_BLANK_UNBLANK ||
 		bd->props.fb_blank != FB_BLANK_UNBLANK ||
@@ -325,7 +318,7 @@ static int backlight_init(struct i2c_mipi_dsi *md)
 	return 0;
 }
 
-////////////////////////////////////////////////////////////////////////////////
+
 // I2C driver
 
 static int i2c_md_probe(struct i2c_client *i2c, const struct i2c_device_id *id)
@@ -461,7 +454,7 @@ static struct i2c_driver i2c_md_driver = {
 	.shutdown = i2c_md_shutdown,
 };
 
-////////////////////////////////////////////////////////////////////////////////
+
 // Kernel module
 
 static int __init i2c_md_init(void)
@@ -500,5 +493,3 @@ MODULE_AUTHOR("Zhangqun Ming <north_sea@qq.com>");
 MODULE_AUTHOR("Seeed, Inc.");
 MODULE_DESCRIPTION("MIPI-DSI driver");
 MODULE_LICENSE("GPL v2");
-
-////////////////////////////////////////////////////////////////////////////////

--- a/modules/mipi_dsi/panel-ili9881d.c
+++ b/modules/mipi_dsi/panel-ili9881d.c
@@ -31,6 +31,8 @@ static int ili9881d_get_modes(struct drm_panel *panel, struct drm_connector *con
 {
 	struct drm_display_mode *mode;
 
+	// DBG_PRINT("Get ILI9881D mode");
+
 	mode = drm_mode_duplicate(connector->dev, &ili9881d_modes);
 	if (!mode) {
 		dev_err(panel->dev, "failed to add mode %ux%u@%u\n",
@@ -57,14 +59,14 @@ static int ili9881d_prepare(struct drm_panel *panel)
 	u16 addr = 0xda;
 	u32 val[4] = {0};
 
-	DBG_FUNC();
+	DBG_PRINT("Prepare ILI9881D");
 
 	if (!dsi)
 		return -1;
 
 	ret = mipi_dsi_generic_read(dsi, &addr, sizeof(addr), &val, sizeof(val));
 	if(ret < 0){
-		DBG_FUNC("No LCD connected,pls check your hardware!\n");
+		DBG_FUNC("No LCD connected,pls check your hardware!");
 		return -ENODEV;
 	}
 	


### PR DESCRIPTION
I changed code comments and printk messages only.

**Test environment:**
* reTerminal 06/09/21
* STM32 firmware v1.9
* Raspberry Pi OS bookwarm 64bit
  ```
  Raspberry Pi reference 2023-10-10
  Generated using pi-gen, https://github.com/RPi-Distro/pi-gen, 962bf483c8f326405794827cce8c0313fd5880a8, stage4
  ```

**dmesg:**
```
$ dmesg | grep mipi
[    7.295511] mipi_dsi: Initialize kernel module
[    7.295537] mipi_dsi: (i2c_md_init) Add I2C driver
[    7.295689] mipi_dsi: Probe I2C driver
[    7.295701] mipi_dsi: (i2c_md_probe) Start
[    7.307029] mipi_dsi: Add MIPI-DSI device to device tree
[    7.307321] mipi_dsi: (i2c_md_probe) Add panel
[    7.307948] mipi_dsi: (backlight_init) Register backlight device
[    7.308072] mipi_dsi: (backlight_update) brightness=255
[    7.311454] mipi_dsi: (i2c_md_probe) Finish
[    7.311999] mipi_dsi: (i2c_md_init) Register MIPI-DSI driver
[    7.312072] mipi_dsi: Probe MIPI-DSI driver
[    7.579274] mipi_dsi: Prepare panel
[    7.676123] mipi_dsi: Prepare ILI9881D
[    7.823927] mipi_dsi: Enable panel
[    9.719939] mipi_dsi: (backlight_update) brightness=255
```
