### PR TITLE
Fix "Can't find mipi_dsi_host!" error

### DIFF
--- a/modules/mipi_dsi/mipi_dsi_drv.c
+++ b/modules/mipi_dsi/mipi_dsi_drv.c
@@ -473,13 +473,13 @@ static int __init i2c_md_init(void)
 
 	DBG_PRINT("Initialize kernel module");
 
-	DBG_FUNC("Register MIPI-DSI driver");
-	ret = mipi_dsi_driver_register(&mipi_dsi_driver);
+	DBG_FUNC("Add I2C driver");
+	ret = i2c_add_driver(&i2c_md_driver);
 	if (ret < 0)
 		return ret;
 
-	DBG_FUNC("Add I2C driver");
-	ret = i2c_add_driver(&i2c_md_driver);
+	DBG_FUNC("Register MIPI-DSI driver");
+	ret = mipi_dsi_driver_register(&mipi_dsi_driver);
 	if (ret < 0)
 		return ret;
 
@@ -491,11 +491,11 @@ static void __exit i2c_md_exit(void)
 {
 	DBG_PRINT("Exit kernel module");
 
-	DBG_FUNC("Delete I2C driver");
-	i2c_del_driver(&i2c_md_driver);
-
 	DBG_FUNC("Unregister MIPI-DSI driver");
 	mipi_dsi_driver_unregister(&mipi_dsi_driver);
+
+	DBG_FUNC("Delete I2C driver");
+	i2c_del_driver(&i2c_md_driver);
 }
 module_exit(i2c_md_exit);
 

--- a/modules/mipi_dsi/mipi_dsi_drv.c
+++ b/modules/mipi_dsi/mipi_dsi_drv.c
@@ -420,7 +420,6 @@ static void i2c_md_remove(struct i2c_client *i2c)
 	mipi_dsi_detach(md->dsi);
 	drm_panel_remove(&md->panel);
 	mipi_dsi_device_unregister(md->dsi);
-	kfree(md->dsi);
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	return 0;
@@ -443,8 +442,6 @@ static void i2c_md_shutdown(struct i2c_client *i2c)
 	mipi_dsi_detach(md->dsi);
 	drm_panel_remove(&md->panel);
 	mipi_dsi_device_unregister(md->dsi);
-	kfree(md->dsi);
-
 }
 
 extern const struct panel_data ili9881d_data;

--- a/modules/mipi_dsi/mipi_dsi_drv.c
+++ b/modules/mipi_dsi/mipi_dsi_drv.c
@@ -417,9 +417,13 @@ static void i2c_md_remove(struct i2c_client *i2c)
 	i2c_md_write(md, REG_LCD_RST, 0);
 	i2c_md_write(md, REG_PWM, 0);
 
-	mipi_dsi_detach(md->dsi);
-	drm_panel_remove(&md->panel);
-	mipi_dsi_device_unregister(md->dsi);
+	if (md->dsi) {
+		mipi_dsi_detach(md->dsi);
+		drm_panel_remove(&md->panel);
+		mipi_dsi_device_unregister(md->dsi);
+		kfree(md->dsi);
+		md->dsi = NULL;
+	}
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	return 0;
@@ -439,9 +443,13 @@ static void i2c_md_shutdown(struct i2c_client *i2c)
 	i2c_md_write(md, REG_LCD_RST, 0);
 	i2c_md_write(md, REG_PWM, 0);
 
-	mipi_dsi_detach(md->dsi);
-	drm_panel_remove(&md->panel);
-	mipi_dsi_device_unregister(md->dsi);
+	if (md->dsi) {
+		mipi_dsi_detach(md->dsi);
+		drm_panel_remove(&md->panel);
+		mipi_dsi_device_unregister(md->dsi);
+		kfree(md->dsi);
+		md->dsi = NULL;
+	}
 }
 
 extern const struct panel_data ili9881d_data;

--- a/modules/mipi_dsi/mipi_dsi_drv.c
+++ b/modules/mipi_dsi/mipi_dsi_drv.c
@@ -417,13 +417,9 @@ static void i2c_md_remove(struct i2c_client *i2c)
 	i2c_md_write(md, REG_LCD_RST, 0);
 	i2c_md_write(md, REG_PWM, 0);
 
-	if (md->dsi) {
-		mipi_dsi_detach(md->dsi);
-		drm_panel_remove(&md->panel);
-		mipi_dsi_device_unregister(md->dsi);
-		kfree(md->dsi);
-		md->dsi = NULL;
-	}
+	mipi_dsi_detach(md->dsi);
+	drm_panel_remove(&md->panel);
+	mipi_dsi_device_unregister(md->dsi);
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
 	return 0;
@@ -443,13 +439,9 @@ static void i2c_md_shutdown(struct i2c_client *i2c)
 	i2c_md_write(md, REG_LCD_RST, 0);
 	i2c_md_write(md, REG_PWM, 0);
 
-	if (md->dsi) {
-		mipi_dsi_detach(md->dsi);
-		drm_panel_remove(&md->panel);
-		mipi_dsi_device_unregister(md->dsi);
-		kfree(md->dsi);
-		md->dsi = NULL;
-	}
+	mipi_dsi_detach(md->dsi);
+	drm_panel_remove(&md->panel);
+	mipi_dsi_device_unregister(md->dsi);
 }
 
 extern const struct panel_data ili9881d_data;

--- a/modules/mipi_dsi/panel-ili9881d.c
+++ b/modules/mipi_dsi/panel-ili9881d.c
@@ -303,9 +303,6 @@ static const struct drm_panel_funcs ili9881d_funcs = {
 static void ili9881d_set_dsi(struct mipi_dsi_device *dsi)
 {
 	ili9881d_dsi = dsi;
-	dsi->mode_flags = (MIPI_DSI_MODE_VIDEO /*| MIPI_DSI_MODE_VIDEO_SYNC_PULSE*/);
-	dsi->format = MIPI_DSI_FMT_RGB888;
-	dsi->lanes = 4;
 }
 
 const struct panel_data ili9881d_data = {


### PR DESCRIPTION
> https://github.com/Seeed-Studio/seeed-linux-dtoverlays/issues/28#issue-979865119
> 
> When reTerminal is powered off and powered back on, mipi LCD driver is not loaded. Need to do the following steps every time I turn on reTerminal

Fixed this issue.

**dmesg log:**

```
ubuntu@ubuntu-desktop:~/seeed-linux-dtoverlays$ sudo dmesg | grep mipi_dsi
[    6.723403] mipi_dsi: loading out-of-tree module taints kernel.
[    6.726237] mipi_dsi: Initialize kernel module
[    6.726254] mipi_dsi: (i2c_md_init) Register MIPI-DSI driver
[    6.726323] mipi_dsi: (i2c_md_init) Add I2C driver
[    6.731800] mipi_dsi: Probe I2C driver
[    6.731816] mipi_dsi: (i2c_md_probe) Start
[    6.744125] mipi_dsi: (i2c_md_probe) STM32 firmware version 1.9
[    6.748474] mipi_dsi: Add MIPI-DSI device to device tree
[    6.748573] mipi_dsi 1-0045: Can't find mipi_dsi_host!
[    6.748619] mipi_dsi 1-0045: DSI device registration failed!
[    6.845744] mipi_dsi: Probe I2C driver
[    6.845760] mipi_dsi: (i2c_md_probe) Start
[    6.849214] mipi_dsi: (i2c_md_probe) STM32 firmware version 1.9
[    6.851040] mipi_dsi: Add MIPI-DSI device to device tree
[    6.851082] mipi_dsi 1-0045: Can't find mipi_dsi_host!
[    6.851131] mipi_dsi 1-0045: DSI device registration failed!
[    6.863274] mipi_dsi: Probe I2C driver
[    6.863293] mipi_dsi: (i2c_md_probe) Start
[    6.866733] mipi_dsi: (i2c_md_probe) STM32 firmware version 1.9
[    6.868306] mipi_dsi: Add MIPI-DSI device to device tree
[    6.868340] mipi_dsi 1-0045: Can't find mipi_dsi_host!
[    6.868381] mipi_dsi 1-0045: DSI device registration failed!
[    6.915367] mipi_dsi: Probe I2C driver
[    6.915384] mipi_dsi: (i2c_md_probe) Start
[    6.918937] mipi_dsi: (i2c_md_probe) STM32 firmware version 1.9
[    6.920670] mipi_dsi: Add MIPI-DSI device to device tree
[    6.920705] mipi_dsi 1-0045: Can't find mipi_dsi_host!
[    6.920748] mipi_dsi 1-0045: DSI device registration failed!
[    6.982108] mipi_dsi: Probe I2C driver
[    6.982124] mipi_dsi: (i2c_md_probe) Start
[    6.985600] mipi_dsi: (i2c_md_probe) STM32 firmware version 1.9
[    6.987250] mipi_dsi: Add MIPI-DSI device to device tree
[    6.987282] mipi_dsi 1-0045: Can't find mipi_dsi_host!
[    6.987323] mipi_dsi 1-0045: DSI device registration failed!
[    6.992312] mipi_dsi: Probe I2C driver
[    6.992329] mipi_dsi: (i2c_md_probe) Start
[    6.995745] mipi_dsi: (i2c_md_probe) STM32 firmware version 1.9
[    6.997475] mipi_dsi: Add MIPI-DSI device to device tree
[    6.997652] mipi_dsi 1-0045: Can't find mipi_dsi_host!
[    6.998006] mipi_dsi 1-0045: DSI device registration failed!
[    7.020986] mipi_dsi: Probe I2C driver
[    7.021004] mipi_dsi: (i2c_md_probe) Start
[    7.024251] mipi_dsi: (i2c_md_probe) STM32 firmware version 1.9
[    7.025918] mipi_dsi: Add MIPI-DSI device to device tree
[    7.035593] mipi_dsi: Probe MIPI-DSI driver
[    7.035716] mipi_dsi: (i2c_md_probe) Add panel
[    7.040637] mipi_dsi: (backlight_init) Register backlight device
[    7.040803] mipi_dsi: (backlight_update) brightness=255
[    7.044112] mipi_dsi: (i2c_md_probe) Finish
[    7.362391] mipi_dsi: Prepare panel
[    7.424844] mipi_dsi: Prepare ILI9881D
[    7.552152] mipi_dsi: Enable panel
[    8.893970] mipi_dsi: (backlight_update) brightness=255
```

**links:**

* [panel-raspberrypi-touchscreen.c](https://github.com/raspberrypi/linux/blob/rpi-5.15.y/drivers/gpu/drm/panel/panel-raspberrypi-touchscreen.c)
