### PR TITLE
modified the kernel version appropriately to make it compatible with ubuntu23.10 (kernel 6.5)

### DIFF
--- a/modules/bq24179_charger/bq25790_charger.c
+++ b/modules/bq24179_charger/bq25790_charger.c
@@ -1104,7 +1104,7 @@ static int bq25790_parse_dt(struct bq25790_device *bq)
 	return 0;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 20)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
 static int bq25790_probe(struct i2c_client *client)
 #else
 static int bq25790_probe(struct i2c_client *client,

--- a/modules/lis3lv02d/lis3lv02d_i2c.c
+++ b/modules/lis3lv02d/lis3lv02d_i2c.c
@@ -101,7 +101,7 @@ static const struct of_device_id lis3lv02d_i2c_dt_ids[] = {
 MODULE_DEVICE_TABLE(of, lis3lv02d_i2c_dt_ids);
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 20)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
 static int lis3lv02d_i2c_probe(struct i2c_client *client)
 #else
 static int lis3lv02d_i2c_probe(struct i2c_client *client,

--- a/modules/ltr30x/ltr30x.c
+++ b/modules/ltr30x/ltr30x.c
@@ -1413,14 +1413,14 @@ static const char *ltr501_match_acpi_device(struct device *dev, int *chip_idx)
 	return dev_name(dev);
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 20)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
 static int ltr501_probe(struct i2c_client *client)
 #else
 static int ltr501_probe(struct i2c_client *client,
                        const struct i2c_device_id *id)
 #endif
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 20)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
 	const struct i2c_device_id *id = i2c_client_get_device_id(client);
 #endif
 	struct ltr501_data *data;

--- a/modules/mipi_dsi/mipi_dsi_drv.c
+++ b/modules/mipi_dsi/mipi_dsi_drv.c
@@ -325,7 +325,7 @@ static int backlight_init(struct i2c_mipi_dsi *md)
 
 
 // I2C driver
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 20)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
 static int i2c_md_probe(struct i2c_client *i2c)
 #else
 static int i2c_md_probe(struct i2c_client *i2c, const struct i2c_device_id *id)

--- a/modules/mipi_dsi/mipi_dsi_drv.c
+++ b/modules/mipi_dsi/mipi_dsi_drv.c
@@ -379,7 +379,7 @@ static int i2c_md_probe(struct i2c_client *i2c, const struct i2c_device_id *id)
 
 	DBG_FUNC("Add panel");
 	md->panel_data->set_dsi(md->dsi);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 20)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
 	md->panel.prepare_prev_first = true;
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
 	md->panel.prepare_upstream_first = true;


### PR DESCRIPTION
When building with ubuntu23.10 (kernel 6.5), the previously modified contents are not applied and an error occurs, so I fixed it to the appropriate kernel version.

See. https://github.com/Seeed-Studio/seeed-linux-dtoverlays/issues/95

## log
```
### Current Debian version is bookworm or later

### Install required tool packages
Hit:1 http://ports.ubuntu.com/ubuntu-ports mantic InRelease
Hit:2 http://ports.ubuntu.com/ubuntu-ports mantic-updates InRelease
Hit:3 http://ports.ubuntu.com/ubuntu-ports mantic-security InRelease
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
dkms is already the newest version (3.0.11-1ubuntu10).
0 upgraded, 0 newly installed, 0 to remove and 17 not upgraded.

### Will compile with the latest kernel...

### Sync kernel and userland

### Uninstall previous dkms module

### Install required kernel package
Reading package lists...
Building dependency tree...
Reading state information...
linux-raspi is already the newest version (6.5.0.1013.14).
linux-headers-raspi is already the newest version (6.5.0.1013.14).
linux-image-raspi is already the newest version (6.5.0.1013.14).
0 upgraded, 0 newly installed, 0 to remove and 17 not upgraded.
KBUILD: /lib/modules/6.5.0-1013-raspi/build
Sign command: /usr/bin/kmodsign
Binary update-secureboot-policy not found, modules won't be signed
Creating symlink /var/lib/dkms/mipi_dsi/0.1/source -> /usr/src/mipi_dsi-0.1

Building module:
Cleaning build area...
make -j4 KERNELRELEASE=6.5.0-1013-raspi all KVERSION=6.5.0-1013-raspi......
Cleaning build area...

mipi_dsi.ko.zst:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/6.5.0-1013-raspi/updates/dkms/
depmod....
Sign command: /usr/bin/kmodsign
Binary update-secureboot-policy not found, modules won't be signed
Creating symlink /var/lib/dkms/ltr30x/0.1/source -> /usr/src/ltr30x-0.1

Building module:
Cleaning build area...
make -j4 KERNELRELEASE=6.5.0-1013-raspi all KVERSION=6.5.0-1013-raspi.....
Cleaning build area...

als_ltr30x.ko.zst:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/6.5.0-1013-raspi/updates/dkms/
depmod....
Sign command: /usr/bin/kmodsign
Binary update-secureboot-policy not found, modules won't be signed
Creating symlink /var/lib/dkms/lis3lv02d/0.1/source -> /usr/src/lis3lv02d-0.1

Building module:
Cleaning build area...
make -j4 KERNELRELEASE=6.5.0-1013-raspi all KVERSION=6.5.0-1013-raspi.......
Cleaning build area...

lis331dlh-i2c.ko.zst:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/6.5.0-1013-raspi/updates/dkms/
depmod....
Sign command: /usr/bin/kmodsign
Binary update-secureboot-policy not found, modules won't be signed
Creating symlink /var/lib/dkms/bq24179_charger/0.1/source -> /usr/src/bq24179_charger-0.1

Building module:
Cleaning build area...
make -j4 KERNELRELEASE=6.5.0-1013-raspi all KVERSION=6.5.0-1013-raspi.....
Cleaning build area...

bq24179_charger.ko.zst:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/6.5.0-1013-raspi/updates/dkms/
depmod....
  DTC     overlays/rpi/reTerminal-overlay.dtbo
'overlays/rpi/reTerminal-overlay.dtbo' -> '/boot/firmware/overlays/reTerminal.dtbo'
------------------------------------------------------
Please reboot your device to apply all settings
Enjoy!
------------------------------------------------------

```