### PR TITLE
Kernel 6.12 Patches

### DIFF
--- a/modules/bq24179_charger/bq25790_charger.c
+++ b/modules/bq24179_charger/bq25790_charger.c
@@ -131,14 +131,6 @@ static int bq25790_watchdog_time[BQ25790_NUM_WD_VAL] = {0, 500, 1000, 2000,
 							20000, 40000, 80000,
 							160000};
 
-static enum power_supply_usb_type bq25790_usb_type[] = {
-	POWER_SUPPLY_USB_TYPE_ACA,
-	POWER_SUPPLY_USB_TYPE_SDP,
-	POWER_SUPPLY_USB_TYPE_CDP,
-	POWER_SUPPLY_USB_TYPE_DCP,
-	POWER_SUPPLY_USB_TYPE_UNKNOWN,
-};
-
 static int bq25790_usb_notifier(struct notifier_block *nb, unsigned long val,
 				void *priv)
 {
@@ -918,8 +910,11 @@ static int bq25790_property_is_writeable(struct power_supply *psy,
 static const struct power_supply_desc bq25790_power_supply_desc = {
 	.name = "bq25790-charger",
 	.type = POWER_SUPPLY_TYPE_USB,
-	.usb_types = bq25790_usb_type,
-	.num_usb_types = ARRAY_SIZE(bq25790_usb_type),
+	.usb_types = BIT(POWER_SUPPLY_USB_TYPE_ACA)|
+	BIT(POWER_SUPPLY_USB_TYPE_SDP)|
+	BIT(POWER_SUPPLY_USB_TYPE_CDP)|
+	BIT(POWER_SUPPLY_USB_TYPE_DCP)|
+	BIT(POWER_SUPPLY_USB_TYPE_UNKNOWN),
 	.properties = bq25790_power_supply_props,
 	.num_properties = ARRAY_SIZE(bq25790_power_supply_props),
 	.get_property = bq25790_charger_get_property,

--- a/modules/lis3lv02d/lis3lv02d.c
+++ b/modules/lis3lv02d/lis3lv02d.c
@@ -662,7 +662,7 @@ static int lis3lv02d_misc_fasync(int fd, struct file *file, int on)
 
 static const struct file_operations lis3lv02d_misc_fops = {
 	.owner   = THIS_MODULE,
-	.llseek  = no_llseek,
+	.llseek  = noop_llseek,
 	.read    = lis3lv02d_misc_read,
 	.open    = lis3lv02d_misc_open,
 	.release = lis3lv02d_misc_release,

--- a/modules/lis3lv02d/lis3lv02d.c
+++ b/modules/lis3lv02d/lis3lv02d.c
@@ -662,7 +662,9 @@ static int lis3lv02d_misc_fasync(int fd, struct file *file, int on)
 
 static const struct file_operations lis3lv02d_misc_fops = {
 	.owner   = THIS_MODULE,
-	.llseek  = noop_llseek,
+#if (LINUX_VERSION_CODE <= KERNEL_VERSION(6, 12, 20))
+        .llseek  = no_llseek,
+#endif
 	.read    = lis3lv02d_misc_read,
 	.open    = lis3lv02d_misc_open,
 	.release = lis3lv02d_misc_release,


### PR DESCRIPTION
This fixes a couple of issues I was having with kernel 6.12 and reTerminal.  I was able to successfully build on a freshly flashed reTerminal using the v1.1.1 image from https://github.com/Seeed-Studio/pi-gen-expand

## Charger Module (bq25790_charger.c):
 - Replaced the bq25790_usb_type array with bitwise operations for USB types.
## Sensor Module (lis3lv02d.c):
- Changed llseek file operation from no_llseek to noop_llseek.